### PR TITLE
Key Connect CLI

### DIFF
--- a/.idea-run-configurations/KeyConnectApplication.run.xml
+++ b/.idea-run-configurations/KeyConnectApplication.run.xml
@@ -1,6 +1,16 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="KeyConnectApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="keyconnect-server" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" />
+      </ENTRIES>
+    </extension>
     <option name="SPRING_BOOT_MAIN_CLASS" value="app.keyconnect.server.KeyConnectApplication" />
     <option name="VM_PARAMETERS" value="-DETH_MAINNET_ADDR=https://mainnet.infura.io/v3/INFURA_KEY -DETH_ROPSTEN_ADDR=https://ropsten.infura.io/v3/INFURA_KEY -DETHERSCAN_TOKEN=ETHERSCAN_TOKEN" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/keyconnect-api/pom.xml
+++ b/keyconnect-api/pom.xml
@@ -120,10 +120,10 @@
                 <serializableModel>true</serializableModel>
                 <sourceFolder>src/gen/java/main</sourceFolder>
               </configOptions>
-              <generateApiTests>true</generateApiTests>
+              <generateApiTests>false</generateApiTests>
               <generateApis>true</generateApis>
               <generateApiDocumentation>true</generateApiDocumentation>
-              <generateModelTests>true</generateModelTests>
+              <generateModelTests>false</generateModelTests>
             </configuration>
           </execution>
           <execution>

--- a/keyconnect-api/src/main/resources/api.yaml
+++ b/keyconnect-api/src/main/resources/api.yaml
@@ -705,3 +705,21 @@ components:
           example: "https://s.altnet.rippletest.net:51234/"
         fee:
           $ref: '#/components/schemas/CurrencyValue'
+    ExceptionalResponse:
+      properties:
+        timestamp:
+          type: number
+          example: 1609519112841
+        status:
+          type: integer
+          example: 400
+        error:
+          type: string
+          example: Bad Request
+        message:
+          type: string
+          example: "Specified network is not a valid network for the block chain"
+        path:
+          type: string
+          example: "/v1/blockchains/xrp/accounts/rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv/transactions"
+

--- a/keyconnect-cli/README.md
+++ b/keyconnect-cli/README.md
@@ -1,0 +1,34 @@
+# Key Connect CLI
+
+Command line interface for the Key Connect Server.
+
+## Build
+To compile the package the artifacts, run:
+```
+mvn package
+```
+
+## Usage
+Run `java -jar keyconnect-cli-1.10-SNAPSHOT-jar-with-dependencies.jar -h` to view usage instructions:
+```
+Usage: kc [-hV] [COMMAND]
+Key Connect command line interface
+  -h, --help      Show this help message and exit.
+  -V, --version   Print version information and exit.
+Commands:
+  server-status, server, srv               Print server status
+  status, s                                Print high-level status of supported
+                                             block chains
+  accounts, a                              Print information for a given
+                                             account / wallet address
+  account-transactions, transactions, txs  Print transactions for a given
+                                             account / wallet address
+  transaction, tx, txn, hash               Print details of a given transaction
+                                             ID (hash)
+  fees                                     Print fees for a given blockchain
+Exit codes:
+  10            Generic non-api related error, mostly an issue with the CLI or
+                  the environment
+  20            Network or connection related error
+  [HTTP Code]   Exit code is the HTTP status code returned by the server
+```

--- a/keyconnect-cli/pom.xml
+++ b/keyconnect-cli/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>app.keyconnect.api</groupId>
       <artifactId>keyconnect-api</artifactId>
-      <version>1.0.0</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/keyconnect-cli/pom.xml
+++ b/keyconnect-cli/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>keyconnect</artifactId>
+    <groupId>app.keyconnect</groupId>
+    <version>1.10-SNAPSHOT</version>
+  </parent>
+  <packaging>jar</packaging>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>keyconnect-cli</artifactId>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>4.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>app.keyconnect.api</groupId>
+      <artifactId>keyconnect-api</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>app.keyconnect.cli.CommandLineApplication</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/keyconnect-cli/pom.xml
+++ b/keyconnect-cli/pom.xml
@@ -29,6 +29,11 @@
       <artifactId>keyconnect-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>2.1.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/keyconnect-cli/pom.xml
+++ b/keyconnect-cli/pom.xml
@@ -34,6 +34,16 @@
       <artifactId>jansi</artifactId>
       <version>2.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.11.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.11.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/keyconnect-cli/pom.xml
+++ b/keyconnect-cli/pom.xml
@@ -13,7 +13,11 @@
 
   <artifactId>keyconnect-cli</artifactId>
 
+  <name>Key Connect CLI</name>
+  <description>CLI Client for Key Connect Server</description>
+
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -11,7 +11,7 @@ import picocli.CommandLine;
 public class CommandLineApplication {
 
   public static void main(String[] args) {
-    new CommandLine(new TopLevelCommand())
+    new CommandLine(new KcCommand())
         .addSubcommand(new ServerStatusCommand())
         .addSubcommand(new BlockchainStatusCommand())
         .addSubcommand(new AccountsCommand())

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -1,11 +1,15 @@
 package app.keyconnect.cli;
 
+import app.keyconnect.api.ApiException;
+import app.keyconnect.api.client.model.ExceptionalResponse;
 import app.keyconnect.cli.commands.AccountTransactionsCommand;
 import app.keyconnect.cli.commands.AccountsCommand;
 import app.keyconnect.cli.commands.BlockchainStatusCommand;
 import app.keyconnect.cli.commands.FeesCommand;
 import app.keyconnect.cli.commands.ServerStatusCommand;
 import app.keyconnect.cli.commands.TransactionCommand;
+import com.google.gson.Gson;
+import java.net.ConnectException;
 import picocli.CommandLine;
 
 public class CommandLineApplication {
@@ -18,6 +22,25 @@ public class CommandLineApplication {
         .addSubcommand(new AccountTransactionsCommand())
         .addSubcommand(new TransactionCommand())
         .addSubcommand(new FeesCommand())
+        .setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
+          if (!(ex instanceof ApiException)) {
+            System.out.println(ex);
+            return 10;
+          }
+
+          final ApiException apiException = (ApiException) ex;
+          final Throwable exceptionCause = apiException.getCause();
+          if (exceptionCause instanceof ConnectException) {
+            System.out.println(exceptionCause.getMessage());
+            return 20;
+          }
+
+          final String responseBody = apiException.getResponseBody();
+          final ExceptionalResponse exceptionalResponse = new Gson()
+              .fromJson(responseBody, ExceptionalResponse.class);
+          System.out.println(exceptionalResponse);
+          return 30;
+        })
         .execute(args);
   }
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -8,6 +8,7 @@ import app.keyconnect.cli.commands.BlockchainStatusCommand;
 import app.keyconnect.cli.commands.FeesCommand;
 import app.keyconnect.cli.commands.ServerStatusCommand;
 import app.keyconnect.cli.commands.TransactionCommand;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import com.google.gson.Gson;
 import java.net.ConnectException;
 import org.fusesource.jansi.AnsiConsole;
@@ -32,14 +33,14 @@ public class CommandLineApplication {
           .addSubcommand(new FeesCommand())
           .setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
             if (!(ex instanceof ApiException)) {
-              System.out.println(ex);
+              ConsoleUtil.print(ex);
               return GENERIC_ERROR_CODE;
             }
 
             final ApiException apiException = (ApiException) ex;
             final Throwable exceptionCause = apiException.getCause();
             if (exceptionCause instanceof ConnectException) {
-              System.out.println(exceptionCause.getMessage());
+              ConsoleUtil.print(exceptionCause.getMessage());
               return CONNECTION_ERROR_CODE;
             }
 
@@ -47,7 +48,7 @@ public class CommandLineApplication {
             final ExceptionalResponse exceptionalResponse = new Gson()
                 .fromJson(responseBody, ExceptionalResponse.class);
 
-            System.out.println(exceptionalResponse);
+            ConsoleUtil.print(exceptionalResponse);
 
             return apiException.getCode();
           })

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -10,12 +10,18 @@ import app.keyconnect.cli.commands.ServerStatusCommand;
 import app.keyconnect.cli.commands.TransactionCommand;
 import com.google.gson.Gson;
 import java.net.ConnectException;
+import org.fusesource.jansi.AnsiConsole;
 import picocli.CommandLine;
+import picocli.CommandLine.Help.Ansi;
 
 public class CommandLineApplication {
 
+  public static final int GENERIC_ERROR_CODE = 10;
+  public static final int CONNECTION_ERROR_CODE = 20;
+
   public static void main(String[] args) {
-    new CommandLine(new KcCommand())
+    AnsiConsole.systemInstall();
+    final int exitCode = new CommandLine(new KcCommand())
         .addSubcommand(new ServerStatusCommand())
         .addSubcommand(new BlockchainStatusCommand())
         .addSubcommand(new AccountsCommand())
@@ -25,23 +31,27 @@ public class CommandLineApplication {
         .setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
           if (!(ex instanceof ApiException)) {
             System.out.println(ex);
-            return 10;
+            return GENERIC_ERROR_CODE;
           }
 
           final ApiException apiException = (ApiException) ex;
           final Throwable exceptionCause = apiException.getCause();
           if (exceptionCause instanceof ConnectException) {
             System.out.println(exceptionCause.getMessage());
-            return 20;
+            return CONNECTION_ERROR_CODE;
           }
 
           final String responseBody = apiException.getResponseBody();
           final ExceptionalResponse exceptionalResponse = new Gson()
               .fromJson(responseBody, ExceptionalResponse.class);
-          System.out.println(exceptionalResponse);
-          return 30;
-        })
-        .execute(args);
-  }
 
+          System.out.println(exceptionalResponse);
+
+          return apiException.getCode();
+        })
+        .setColorScheme(CommandLine.Help.defaultColorScheme(Ansi.ON))
+        .execute(args);
+    AnsiConsole.systemUninstall();
+    System.exit(exitCode);
+  }
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -1,0 +1,24 @@
+package app.keyconnect.cli;
+
+import app.keyconnect.cli.commands.AccountTransactionsCommand;
+import app.keyconnect.cli.commands.AccountsCommand;
+import app.keyconnect.cli.commands.BlockchainStatusCommand;
+import app.keyconnect.cli.commands.FeesCommand;
+import app.keyconnect.cli.commands.ServerStatusCommand;
+import app.keyconnect.cli.commands.TransactionCommand;
+import picocli.CommandLine;
+
+public class CommandLineApplication {
+
+  public static void main(String[] args) {
+    new CommandLine(new TopLevelCommand())
+        .addSubcommand(new ServerStatusCommand())
+        .addSubcommand(new BlockchainStatusCommand())
+        .addSubcommand(new AccountsCommand())
+        .addSubcommand(new AccountTransactionsCommand())
+        .addSubcommand(new TransactionCommand())
+        .addSubcommand(new FeesCommand())
+        .execute(args);
+  }
+
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/CommandLineApplication.java
@@ -20,38 +20,43 @@ public class CommandLineApplication {
   public static final int CONNECTION_ERROR_CODE = 20;
 
   public static void main(String[] args) {
-    AnsiConsole.systemInstall();
-    final int exitCode = new CommandLine(new KcCommand())
-        .addSubcommand(new ServerStatusCommand())
-        .addSubcommand(new BlockchainStatusCommand())
-        .addSubcommand(new AccountsCommand())
-        .addSubcommand(new AccountTransactionsCommand())
-        .addSubcommand(new TransactionCommand())
-        .addSubcommand(new FeesCommand())
-        .setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
-          if (!(ex instanceof ApiException)) {
-            System.out.println(ex);
-            return GENERIC_ERROR_CODE;
-          }
+    final int exitCode;
+    try {
+      AnsiConsole.systemInstall();
+      exitCode = new CommandLine(new KcCommand())
+          .addSubcommand(new ServerStatusCommand())
+          .addSubcommand(new BlockchainStatusCommand())
+          .addSubcommand(new AccountsCommand())
+          .addSubcommand(new AccountTransactionsCommand())
+          .addSubcommand(new TransactionCommand())
+          .addSubcommand(new FeesCommand())
+          .setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
+            if (!(ex instanceof ApiException)) {
+              System.out.println(ex);
+              return GENERIC_ERROR_CODE;
+            }
 
-          final ApiException apiException = (ApiException) ex;
-          final Throwable exceptionCause = apiException.getCause();
-          if (exceptionCause instanceof ConnectException) {
-            System.out.println(exceptionCause.getMessage());
-            return CONNECTION_ERROR_CODE;
-          }
+            final ApiException apiException = (ApiException) ex;
+            final Throwable exceptionCause = apiException.getCause();
+            if (exceptionCause instanceof ConnectException) {
+              System.out.println(exceptionCause.getMessage());
+              return CONNECTION_ERROR_CODE;
+            }
 
-          final String responseBody = apiException.getResponseBody();
-          final ExceptionalResponse exceptionalResponse = new Gson()
-              .fromJson(responseBody, ExceptionalResponse.class);
+            final String responseBody = apiException.getResponseBody();
+            final ExceptionalResponse exceptionalResponse = new Gson()
+                .fromJson(responseBody, ExceptionalResponse.class);
 
-          System.out.println(exceptionalResponse);
+            System.out.println(exceptionalResponse);
 
-          return apiException.getCode();
-        })
-        .setColorScheme(CommandLine.Help.defaultColorScheme(Ansi.ON))
-        .execute(args);
-    AnsiConsole.systemUninstall();
+            return apiException.getCode();
+          })
+          .setColorScheme(CommandLine.Help.defaultColorScheme(Ansi.ON))
+          .execute(args);
+    } finally {
+      AnsiConsole.systemUninstall();
+    }
+
     System.exit(exitCode);
   }
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
@@ -4,7 +4,14 @@ import picocli.CommandLine.Command;
 
 @Command(name = "kc",
     description = "Key Connect command line interface",
-    mixinStandardHelpOptions = true)
+    mixinStandardHelpOptions = true,
+    exitCodeListHeading = "Exit codes:%n",
+    exitCodeList = {
+        "10:Generic non-api related error, mostly an issue with the CLI or the environment",
+        "20:Network or connection related error",
+        "[HTTP Status Code]:Exit code is the HTTP status code returned by the server"
+    }
+)
 public class KcCommand {
 
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
@@ -9,7 +9,7 @@ import picocli.CommandLine.Command;
     exitCodeList = {
         "10:Generic non-api related error, mostly an issue with the CLI or the environment",
         "20:Network or connection related error",
-        "[HTTP Status Code]:Exit code is the HTTP status code returned by the server"
+        "[HTTP Code]:Exit code is the HTTP status code returned by the server"
     }
 )
 public class KcCommand {

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
@@ -2,7 +2,9 @@ package app.keyconnect.cli;
 
 import picocli.CommandLine.Command;
 
-@Command(name = "kc", description = "Key Connect command line interface", mixinStandardHelpOptions = true)
+@Command(name = "kc",
+    description = "Key Connect command line interface",
+    mixinStandardHelpOptions = true)
 public class KcCommand {
 
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
@@ -2,7 +2,7 @@ package app.keyconnect.cli;
 
 import picocli.CommandLine.Command;
 
-@Command(name = "kc", description = "Key Connect command line interface")
+@Command(name = "kc", description = "Key Connect command line interface", mixinStandardHelpOptions = true)
 public class KcCommand {
 
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/KcCommand.java
@@ -3,6 +3,6 @@ package app.keyconnect.cli;
 import picocli.CommandLine.Command;
 
 @Command(name = "kc", description = "Key Connect command line interface")
-public class TopLevelCommand {
+public class KcCommand {
 
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/TopLevelCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/TopLevelCommand.java
@@ -1,0 +1,8 @@
+package app.keyconnect.cli;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "kc", description = "Key Connect command line interface")
+public class TopLevelCommand {
+
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
@@ -1,0 +1,35 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.cli.config.BaseAccountBlockchainConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+    name = "account-transactions",
+    aliases = {"transactions", "txs"},
+    description = "Prints transactions for a given account"
+)
+public class AccountTransactionsCommand extends BaseAccountBlockchainConfig implements Callable<Integer> {
+
+  @Option(
+      names = {"-p", "--page"},
+      description = "Cursor / Page information"
+  )
+  private String page;
+
+//  @Option(
+//      names = {"-l", "--limit"},
+//      description = "Maximum number of transactions to view"
+//  )
+//  private String limit;
+
+  @Override
+  public Integer call() throws Exception {
+    System.out.println(
+        buildApiClient()
+          .getAccountTransactions(chainId, accountAddress, network, page)
+    );
+    return 0;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
@@ -8,7 +8,7 @@ import picocli.CommandLine.Option;
 @Command(
     name = "account-transactions",
     aliases = {"transactions", "txs"},
-    description = "Prints transactions for a given account"
+    description = "Print transactions for a given account / wallet address"
 )
 public class AccountTransactionsCommand extends BaseAccountBlockchainConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountTransactionsCommand.java
@@ -1,6 +1,7 @@
 package app.keyconnect.cli.commands;
 
 import app.keyconnect.cli.config.BaseAccountBlockchainConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -26,7 +27,7 @@ public class AccountTransactionsCommand extends BaseAccountBlockchainConfig impl
 
   @Override
   public Integer call() throws Exception {
-    System.out.println(
+    ConsoleUtil.print(
         buildApiClient()
           .getAccountTransactions(chainId, accountAddress, network, page)
     );

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
@@ -1,0 +1,28 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.cli.config.BaseBlockchainConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+    name = "accounts",
+    aliases = {"a"},
+    description = "Prints information for a given account"
+)
+public class AccountsCommand extends BaseBlockchainConfig implements Callable<Integer> {
+
+  @Option(
+      names = {"-a", "--account"},
+      description = "Account address",
+      required = true
+  )
+  private String accountAddress;
+
+  @Override
+  public Integer call() throws Exception {
+    System.out.println(buildApiClient()
+        .getAccountInfo(chainId, accountAddress, network));
+    return 0;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
@@ -1,6 +1,7 @@
 package app.keyconnect.cli.commands;
 
 import app.keyconnect.cli.config.BaseBlockchainConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -21,7 +22,7 @@ public class AccountsCommand extends BaseBlockchainConfig implements Callable<In
 
   @Override
   public Integer call() throws Exception {
-    System.out.println(buildApiClient()
+    ConsoleUtil.print(buildApiClient()
         .getAccountInfo(chainId, accountAddress, network));
     return 0;
   }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/AccountsCommand.java
@@ -8,7 +8,7 @@ import picocli.CommandLine.Option;
 @Command(
     name = "accounts",
     aliases = {"a"},
-    description = "Prints information for a given account"
+    description = "Print information for a given account / wallet address"
 )
 public class AccountsCommand extends BaseBlockchainConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
@@ -1,0 +1,22 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.cli.config.BaseClientConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "status",
+    aliases = "s",
+    description = "View high-level status of supported block chains"
+)
+public class BlockchainStatusCommand extends BaseClientConfig implements Callable<Integer> {
+
+  @Override
+  public Integer call() throws Exception {
+    System.out.println(
+        buildApiClient()
+          .getBlockchainsStatus()
+    );
+    return null;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
@@ -7,7 +7,7 @@ import picocli.CommandLine.Command;
 @Command(
     name = "status",
     aliases = "s",
-    description = "View high-level status of supported block chains"
+    description = "Print high-level status of supported block chains"
 )
 public class BlockchainStatusCommand extends BaseClientConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/BlockchainStatusCommand.java
@@ -1,6 +1,7 @@
 package app.keyconnect.cli.commands;
 
 import app.keyconnect.cli.config.BaseClientConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
@@ -13,7 +14,7 @@ public class BlockchainStatusCommand extends BaseClientConfig implements Callabl
 
   @Override
   public Integer call() throws Exception {
-    System.out.println(
+    ConsoleUtil.print(
         buildApiClient()
           .getBlockchainsStatus()
     );

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
@@ -7,7 +7,7 @@ import picocli.CommandLine.Command;
 
 @Command(
     name = "fees",
-    description = "View blockchain fees"
+    description = "Print fees for a given blockchain"
 )
 public class FeesCommand extends BaseBlockchainConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
@@ -1,7 +1,7 @@
 package app.keyconnect.cli.commands;
 
 import app.keyconnect.cli.config.BaseBlockchainConfig;
-import app.keyconnect.cli.config.BaseClientConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
@@ -13,7 +13,7 @@ public class FeesCommand extends BaseBlockchainConfig implements Callable<Intege
 
   @Override
   public Integer call() throws Exception {
-    System.out.println(
+    ConsoleUtil.print(
         buildApiClient()
           .getFee(chainId, network)
     );

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/FeesCommand.java
@@ -1,0 +1,22 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.cli.config.BaseBlockchainConfig;
+import app.keyconnect.cli.config.BaseClientConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "fees",
+    description = "View blockchain fees"
+)
+public class FeesCommand extends BaseBlockchainConfig implements Callable<Integer> {
+
+  @Override
+  public Integer call() throws Exception {
+    System.out.println(
+        buildApiClient()
+          .getFee(chainId, network)
+    );
+    return 0;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
@@ -8,7 +8,7 @@ import picocli.CommandLine.Command;
 @Command(
     name = "server-status",
     aliases = {"server", "srv"},
-    description = "Prints server status"
+    description = "Print server status"
 )
 public class ServerStatusCommand extends BaseClientConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
@@ -2,6 +2,7 @@ package app.keyconnect.cli.commands;
 
 import app.keyconnect.api.client.DefaultApi;
 import app.keyconnect.cli.config.BaseClientConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
@@ -16,7 +17,7 @@ public class ServerStatusCommand extends BaseClientConfig implements Callable<In
   public Integer call() throws Exception {
     final DefaultApi api = buildApiClient();
 
-    System.out.println(api.getServerStatus());
+    ConsoleUtil.print(api.getServerStatus());
     return 0;
   }
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/ServerStatusCommand.java
@@ -1,0 +1,22 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.api.client.DefaultApi;
+import app.keyconnect.cli.config.BaseClientConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "server-status",
+    aliases = {"server", "srv"},
+    description = "Prints server status"
+)
+public class ServerStatusCommand extends BaseClientConfig implements Callable<Integer> {
+
+  @Override
+  public Integer call() throws Exception {
+    final DefaultApi api = buildApiClient();
+
+    System.out.println(api.getServerStatus());
+    return 0;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
@@ -7,8 +7,8 @@ import picocli.CommandLine.Option;
 
 @Command(
     name = "transaction",
-    aliases = {"tx", "txn"},
-    description = "Prints details of a given transaction"
+    aliases = {"tx", "txn", "hash"},
+    description = "Print details of a given transaction ID (hash)"
 )
 public class TransactionCommand extends BaseBlockchainConfig implements Callable<Integer> {
 

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
@@ -1,0 +1,28 @@
+package app.keyconnect.cli.commands;
+
+import app.keyconnect.cli.config.BaseBlockchainConfig;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+    name = "transaction",
+    aliases = {"tx", "txn"},
+    description = "Prints details of a given transaction"
+)
+public class TransactionCommand extends BaseBlockchainConfig implements Callable<Integer> {
+
+  @Option(
+      names = {"-t", "--tx", "--transaction"},
+      description = "Transaction ID",
+      required = true
+  )
+  private String transactionId;
+
+  @Override
+  public Integer call() throws Exception {
+    System.out.println(buildApiClient()
+        .getTransaction(chainId, transactionId, network));
+    return 0;
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/commands/TransactionCommand.java
@@ -1,6 +1,7 @@
 package app.keyconnect.cli.commands;
 
 import app.keyconnect.cli.config.BaseBlockchainConfig;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -21,7 +22,7 @@ public class TransactionCommand extends BaseBlockchainConfig implements Callable
 
   @Override
   public Integer call() throws Exception {
-    System.out.println(buildApiClient()
+    ConsoleUtil.print(buildApiClient()
         .getTransaction(chainId, transactionId, network));
     return 0;
   }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseAccountBlockchainConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseAccountBlockchainConfig.java
@@ -1,0 +1,14 @@
+package app.keyconnect.cli.config;
+
+import picocli.CommandLine.Option;
+
+public class BaseAccountBlockchainConfig extends BaseBlockchainConfig {
+
+  @Option(
+      names = {"-a", "--account"},
+      description = "Account address",
+      required = true
+  )
+  protected String accountAddress;
+
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseBlockchainConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseBlockchainConfig.java
@@ -1,0 +1,20 @@
+package app.keyconnect.cli.config;
+
+import picocli.CommandLine.Option;
+
+public class BaseBlockchainConfig extends BaseClientConfig {
+
+  @Option(
+      names = {"-c", "--chainid"},
+      description = "ID of the blockchain",
+      required = true
+  )
+  protected String chainId;
+
+  @Option(
+      names = {"-n", "--network"},
+      description = "Blockchain network, if other than server-side default"
+  )
+  protected String network;
+
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
@@ -1,0 +1,23 @@
+package app.keyconnect.cli.config;
+
+import app.keyconnect.api.ApiClient;
+import app.keyconnect.api.client.DefaultApi;
+import org.jetbrains.annotations.NotNull;
+import picocli.CommandLine.Option;
+
+public class BaseClientConfig {
+
+  @Option(
+      names = {"-s", "--server"},
+      description = "Base URI of the server, if other than production https://api.keyconnect.app",
+      defaultValue = "https://api.keyconnect.app"
+  )
+  protected String baseUri = "https://api.keyconnect.app";
+
+  @NotNull
+  protected DefaultApi buildApiClient() {
+    return new DefaultApi(
+        new ApiClient().setBasePath(baseUri)
+    );
+  }
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
@@ -2,12 +2,10 @@ package app.keyconnect.cli.config;
 
 import app.keyconnect.api.ApiClient;
 import app.keyconnect.api.client.DefaultApi;
-import app.keyconnect.cli.utils.ConsoleMode;
-import app.keyconnect.cli.utils.ConsoleUtil;
 import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine.Option;
 
-public class BaseClientConfig {
+public class BaseClientConfig extends BaseConfig {
 
   @Option(
       names = {"-s", "--server"},
@@ -22,26 +20,6 @@ public class BaseClientConfig {
       defaultValue = "false"
   )
   private boolean apiDebug;
-
-  @Option(
-      names = {"--print-json", "--json"},
-      description = "Print output in JSON format",
-      defaultValue = "false"
-  )
-  private void setJson(boolean value) {
-    if (value)
-      ConsoleUtil.setMode(ConsoleMode.Json);
-  }
-
-  @Option(
-      names = {"--print-yaml", "--yaml"},
-      description = "Print output in YAML format",
-      defaultValue = "false"
-  )
-  private void setYaml(boolean value) {
-    if (value)
-      ConsoleUtil.setMode(ConsoleMode.Yaml);
-  }
 
   @NotNull
   protected DefaultApi buildApiClient() {

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
@@ -14,10 +14,19 @@ public class BaseClientConfig {
   )
   protected String baseUri = "https://api.keyconnect.app";
 
+  @Option(
+      names = {"--api-debug"},
+      description = "Debug API request/responses",
+      defaultValue = "false"
+  )
+  private boolean apiDebug;
+
   @NotNull
   protected DefaultApi buildApiClient() {
     return new DefaultApi(
-        new ApiClient().setBasePath(baseUri)
+        new ApiClient()
+            .setBasePath(baseUri)
+            .setDebugging(apiDebug)
     );
   }
 }

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseClientConfig.java
@@ -2,6 +2,8 @@ package app.keyconnect.cli.config;
 
 import app.keyconnect.api.ApiClient;
 import app.keyconnect.api.client.DefaultApi;
+import app.keyconnect.cli.utils.ConsoleMode;
+import app.keyconnect.cli.utils.ConsoleUtil;
 import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine.Option;
 
@@ -20,6 +22,26 @@ public class BaseClientConfig {
       defaultValue = "false"
   )
   private boolean apiDebug;
+
+  @Option(
+      names = {"--print-json", "--json"},
+      description = "Print output in JSON format",
+      defaultValue = "false"
+  )
+  private void setJson(boolean value) {
+    if (value)
+      ConsoleUtil.setMode(ConsoleMode.Json);
+  }
+
+  @Option(
+      names = {"--print-yaml", "--yaml"},
+      description = "Print output in YAML format",
+      defaultValue = "false"
+  )
+  private void setYaml(boolean value) {
+    if (value)
+      ConsoleUtil.setMode(ConsoleMode.Yaml);
+  }
 
   @NotNull
   protected DefaultApi buildApiClient() {

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseConfig.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/config/BaseConfig.java
@@ -1,0 +1,29 @@
+package app.keyconnect.cli.config;
+
+import app.keyconnect.cli.utils.ConsoleMode;
+import app.keyconnect.cli.utils.ConsoleUtil;
+import picocli.CommandLine.Option;
+
+public class BaseConfig {
+
+  @Option(
+      names = {"--print-json", "--json"},
+      description = "Print output in JSON format",
+      defaultValue = "false"
+  )
+  private void setJson(boolean value) {
+    if (value)
+      ConsoleUtil.setMode(ConsoleMode.Json);
+  }
+
+  @Option(
+      names = {"--print-yaml", "--yaml"},
+      description = "Print output in YAML format",
+      defaultValue = "false"
+  )
+  private void setYaml(boolean value) {
+    if (value)
+      ConsoleUtil.setMode(ConsoleMode.Yaml);
+  }
+
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleMode.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleMode.java
@@ -1,0 +1,7 @@
+package app.keyconnect.cli.utils;
+
+public enum ConsoleMode {
+  Serialize,
+  Json,
+  Yaml
+}

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleUtil.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleUtil.java
@@ -1,5 +1,6 @@
 package app.keyconnect.cli.utils;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -9,6 +10,11 @@ public class ConsoleUtil {
   private static ConsoleMode mode = ConsoleMode.Serialize;
   private static final ObjectMapper jsonWriter = new ObjectMapper();
   private static final ObjectMapper yamlWriter = new ObjectMapper(new YAMLFactory());
+
+  static {
+    jsonWriter.setSerializationInclusion(Include.NON_NULL);
+    yamlWriter.setSerializationInclusion(Include.NON_NULL);
+  }
 
   public static void print(Object message) {
     final String output;

--- a/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleUtil.java
+++ b/keyconnect-cli/src/main/java/app/keyconnect/cli/utils/ConsoleUtil.java
@@ -1,0 +1,44 @@
+package app.keyconnect.cli.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class ConsoleUtil {
+
+  private static ConsoleMode mode = ConsoleMode.Serialize;
+  private static final ObjectMapper jsonWriter = new ObjectMapper();
+  private static final ObjectMapper yamlWriter = new ObjectMapper(new YAMLFactory());
+
+  public static void print(Object message) {
+    final String output;
+    switch (getMode()) {
+      case Json:
+        try {
+          output = jsonWriter.writeValueAsString(message);
+          break;
+        } catch (JsonProcessingException e) {
+          throw new RuntimeException("Unable to output JSON format", e);
+        }
+      case Yaml:
+        try {
+          output = yamlWriter.writeValueAsString(message);
+          break;
+        } catch (JsonProcessingException e) {
+          throw new RuntimeException("Unable to output YAML format", e);
+        }
+      case Serialize:
+      default:
+        output = message.toString();
+    }
+    System.out.println(output);
+  }
+
+  public static void setMode(ConsoleMode mode) {
+    ConsoleUtil.mode = mode;
+  }
+
+  public static ConsoleMode getMode() {
+    return mode;
+  }
+}

--- a/keyconnect-rippled-api/pom.xml
+++ b/keyconnect-rippled-api/pom.xml
@@ -118,9 +118,9 @@
                 <sourceFolder>src/gen/java/main</sourceFolder>
                 <library>resttemplate</library>
               </configOptions>
-              <generateApiTests>true</generateApiTests>
+              <generateApiTests>false</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
-              <generateModelTests>true</generateModelTests>
+              <generateModelTests>false</generateModelTests>
             </configuration>
           </execution>
         </executions>

--- a/keyconnect-server/pom.xml
+++ b/keyconnect-server/pom.xml
@@ -16,8 +16,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
     <junit-jupiter.version>5.3.2</junit-jupiter.version>
     <start-class>app.keyconnect.server.KeyConnectApplication</start-class>
@@ -45,6 +45,14 @@
       <groupId>org.web3j</groupId>
       <artifactId>core</artifactId>
       <version>5.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -132,6 +140,14 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainGeneratorController.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainGeneratorController.java
@@ -37,7 +37,7 @@ public class BlockchainGeneratorController {
       @RequestParam(value = "destinationTag", required = false) int destinationTag,
       @RequestParam("amount") String amountInDrops,
       @RequestParam(value = "fee", required = false) String feeInDrops,
-      @RequestParam(value = "network", required = false) String network
+      @RequestParam(value = "network", required = false, defaultValue = "mainnet") String network
   ) throws UnknownNetworkException {
     final BlockchainGateway xrpGateway = blockchainGatewayFactory.getGateway(XrpGateway.CHAIN_ID);
 

--- a/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainStatusController.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainStatusController.java
@@ -66,7 +66,7 @@ public class BlockchainStatusController {
   )
   public ResponseEntity<BlockchainStatus> getBlockchainStatus(
       @PathVariable("chainId") String chainId,
-      @RequestParam(value = "network", required = false) String network
+      @RequestParam(value = "network", required = false, defaultValue = "mainnet") String network
   ) {
     final BlockchainGateway g = gatewayFactory.getGateway(chainId);
     if (network != null) {
@@ -118,7 +118,7 @@ public class BlockchainStatusController {
   )
   public ResponseEntity<BlockchainFee> getBlockchainFee(
       @PathVariable("chainId") String chainId,
-      @RequestParam(value = "network", required = false) String network
+      @RequestParam(value = "network", required = false, defaultValue = "mainnet") String network
   ) throws UnknownNetworkException {
     final BlockchainGateway gateway = gatewayFactory.getGateway(chainId);
     final BlockchainFee fee = gateway.getFee(network);

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/BlockchainGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/BlockchainGateway.java
@@ -16,6 +16,8 @@ public interface BlockchainGateway {
 
   String[] getNetworks();
 
+  String validateNetworkOrDefault(String network) throws UnknownNetworkException;
+
   BlockchainNetworkServerStatus[] getNetworkServerStatus(String network)
       throws UnknownNetworkException;
 

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/exceptions/UnknownNetworkException.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/exceptions/UnknownNetworkException.java
@@ -1,5 +1,9 @@
 package app.keyconnect.server.gateways.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "Specified network is not a valid network for the block chain")
 public class UnknownNetworkException extends Exception {
 
   public UnknownNetworkException(String chainId, String specifiedNetwork) {

--- a/keyconnect-server/src/main/resources/application.yml
+++ b/keyconnect-server/src/main/resources/application.yml
@@ -24,12 +24,12 @@ blockchains:
         address: "https://s.devnet.rippletest.net:51234/"
         type: "json-rpc"
       - group: "mainnet"
-        mode: "public"
-        address: "https://s1.ripple.com:51234/"
-        type: "json-rpc"
-      - group: "mainnet"
         mode: "full-history"
         address: "https://s2.ripple.com:51234/"
+        type: "json-rpc"
+      - group: "mainnet"
+        mode: "public"
+        address: "https://s1.ripple.com:51234/"
         type: "json-rpc"
 spring:
   jackson:

--- a/keyconnect-server/src/main/resources/application.yml
+++ b/keyconnect-server/src/main/resources/application.yml
@@ -37,3 +37,7 @@ spring:
       READ_ENUMS_USING_TO_STRING: true
     serialization:
       WRITE_ENUMS_USING_TO_STRING: true
+
+server:
+  error:
+    include-message: always

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <module>keyconnect-server</module>
     <module>keyconnect-rippled-api</module>
     <module>keyconnect-chainbase</module>
+    <module>keyconnect-cli</module>
   </modules>
 
   <name>Key Connect</name>


### PR DESCRIPTION
Usage:
```
java -jar .\target\keyconnect-cli-1.10-SNAPSHOT-jar-with-dependencies.jar
Missing required subcommand
Usage: kc [COMMAND]
Key Connect command line interface
Commands:
  server-status, server, srv               Prints server status
  status, s                                View high-level status of supported
                                             block chains
  accounts, a                              Prints information for a given
                                             account
  account-transactions, transactions, txs  Prints transactions for a given
                                             account
  transaction, tx, txn                     Prints details of a given transaction
  fees                                     View blockchain fees
```

Example call to view account info:
```
java -jar .\target\keyconnect-cli-1.10-SNAPSHOT-jar-with-dependencies.jar accounts -a rDsbeomae4FXwg
QTJp9Rs64Qg9vDiTCdBv -c xrp
class BlockchainAccountInfo {
    chainId: xrp
    network: mainnet
    server: https://s1.ripple.com:51234/
    accountId: rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv
    balance: class CurrencyValue {
        amount: 39663396
        issuer: null
        currency: xrp
    }
    lastTransactionId: C2CD27B682F3946729836F9C57542510195F267F4C53AFAA62636A4CA5485C01
}
```