### PR TITLE
Allow all origins for CORS

### DIFF
--- a/keyconnect-server/src/main/java/app/keyconnect/server/config/WebConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/config/WebConfiguration.java
@@ -1,0 +1,21 @@
+package app.keyconnect.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*");
+      }
+    };
+  }
+
+}


### PR DESCRIPTION
Need to allow all origins for CORS so that direct requests to Key Connect from platforms like web browsers or web browser containers is possible.