### PR TITLE
Separate network client service from gateways

### DIFF
--- a/keyconnect-chainbase/src/main/resources/application.yml
+++ b/keyconnect-chainbase/src/main/resources/application.yml
@@ -5,7 +5,7 @@
 #password: "jaDdIDvV2kbXhSbnL22R"
 
 ethnode:
-  httpAddress: 'http://localhost:8545'
+  httpAddress: 'https://eth.keyconnect.app'
 spring:
   datasource:
     # docker run --rm --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=pgpassword -e POSTGRES_USER=chains -e POSTGRES_DB=chainsdb -it postgres:12

--- a/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainGeneratorController.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/controllers/BlockchainGeneratorController.java
@@ -8,6 +8,7 @@ import app.keyconnect.server.factories.BlockchainGatewayFactory;
 import app.keyconnect.server.gateways.BlockchainGateway;
 import app.keyconnect.server.gateways.XrpGateway;
 import java.math.BigDecimal;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -43,6 +44,7 @@ public class BlockchainGeneratorController {
 
     if (StringUtils.isBlank(feeInDrops)) {
       final CurrencyValue fee = xrpGateway.getFee(network).getFee();
+      Objects.requireNonNull(fee, "Fee for network " + network + " should not be null");
       if (fee.getCurrency() == CurrencyEnum.DROPS) {
         feeInDrops = fee.getAmount();
       } else if (fee.getCurrency() == CurrencyEnum.XRP) {

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
@@ -104,7 +104,7 @@ public class EthereumGateway implements
 
   @Override
   public String[] getNetworks() {
-    return configuration.getNetworks()
+    return networkClientService.getNetworks()
         .stream()
         .map(BlockchainNetworkConfiguration::getGroup)
         .distinct()

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
@@ -68,7 +68,7 @@ public class EthereumGateway implements
   // cache key is network
   private final Map<String, Web3j> serverClients;
   private final LoadingCache<String, EthBlock> latestEthBlockCache;
-  private EtherscanUtil etherscanUtil;
+  private final EtherscanUtil etherscanUtil;
   private final Erc20TokenService tokenService;
 
   public EthereumGateway(

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
@@ -22,6 +22,8 @@ import app.keyconnect.server.gateways.exceptions.FailedToSubmitEthTransactionExc
 import app.keyconnect.server.gateways.exceptions.UnknownNetworkException;
 import app.keyconnect.server.gateways.exceptions.UnsupportedNetworkForEthTransactionsException;
 import app.keyconnect.server.services.Erc20TokenService;
+import app.keyconnect.server.services.networks.NetworkClient;
+import app.keyconnect.server.services.networks.NetworkClientService;
 import app.keyconnect.server.utils.EtherscanUtil;
 import app.keyconnect.server.utils.models.EtherscanResponse;
 import com.google.common.base.Strings;
@@ -37,8 +39,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -54,7 +55,6 @@ import org.web3j.protocol.core.methods.response.EthGetBalance;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.protocol.core.methods.response.Transaction;
-import org.web3j.protocol.http.HttpService;
 
 public class EthereumGateway implements
     BlockchainGateway {
@@ -66,16 +66,16 @@ public class EthereumGateway implements
   public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
   private static final String DEFAULT_NETWORK = "mainnet";
   private final BlockchainsConfiguration configuration;
-  // cache key is network
-  private final Map<String, Web3j> serverClients;
   private final LoadingCache<String, EthBlock> latestEthBlockCache;
   private final EtherscanUtil etherscanUtil;
   private final Erc20TokenService tokenService;
+  private final NetworkClientService<Web3j> networkClientService;
 
   public EthereumGateway(
       YamlConfiguration configuration,
       EtherscanUtil etherscanUtil,
-      Erc20TokenService tokenService) {
+      Erc20TokenService tokenService,
+      NetworkClientService<Web3j> networkClientService) {
     this.configuration = configuration.getBlockchains()
         .stream()
         .filter(b -> b.getType().equalsIgnoreCase(CHAIN_ID))
@@ -83,25 +83,14 @@ public class EthereumGateway implements
         .orElse(new BlockchainsConfiguration());
     this.etherscanUtil = etherscanUtil;
     this.tokenService = tokenService;
-
-    // pre populate server clients cache
-    this.serverClients = new ConcurrentHashMap<>(this.configuration.getNetworks().size());
-    this.configuration.getNetworks()
-        .stream()
-        .map(BlockchainNetworkConfiguration::getAddress)
-        .distinct()
-        .forEach(a -> {
-          final Web3j client = Web3j.build(new HttpService(a));
-          logger.info("Connected to eth node {}", a);
-          this.serverClients.put(a, client);
-        });
+    this.networkClientService = networkClientService;
 
     this.latestEthBlockCache = CacheBuilder.newBuilder()
         .expireAfterWrite(10, TimeUnit.SECONDS)
         .build(new CacheLoader<>() {
           @Override
-          public EthBlock load(@NotNull String network) throws Exception {
-            final Web3j client = serverClients.get(network);
+          public EthBlock load(@NotNull String serverUrl) throws Exception {
+            final Web3j client = EthereumGateway.this.networkClientService.getClientForServer(serverUrl);
             return client.ethGetBlockByNumber(DefaultBlockParameter.valueOf("latest"), false)
                 .sendAsync().get(30, TimeUnit.SECONDS);
           }
@@ -136,17 +125,12 @@ public class EthereumGateway implements
 
   @Override
   public BlockchainNetworkServerStatus[] getNetworkServerStatus(String network) {
-    final List<BlockchainNetworkConfiguration> eligibleNetworks = this.configuration.getNetworks()
+    return networkClientService.getAllMatching(network)
         .stream()
-        .filter(n -> n.getGroup().equalsIgnoreCase(network))
-        .collect(Collectors.toList());
-
-    return eligibleNetworks.stream()
         .map(n -> {
-          final String serverUrl = n.getAddress();
-          final Web3j client = serverClients.get(serverUrl);
+          final String serverUrl = n.getNetwork().getAddress();
           try {
-            final EthBlock latestEthBlock = client
+            final EthBlock latestEthBlock = n.getClient()
                 .ethGetBlockByNumber(DefaultBlockParameter.valueOf("latest"), false)
                 .sendAsync().get(30, TimeUnit.SECONDS);
             return new BlockchainNetworkServerStatus()
@@ -167,15 +151,12 @@ public class EthereumGateway implements
 
   @Override
   public BlockchainFee getFee(String network) {
-    final List<BlockchainNetworkConfiguration> eligibleNetworks = this.configuration.getNetworks()
-        .stream()
-        .filter(n -> n.getGroup().equalsIgnoreCase(network))
-        .collect(Collectors.toList());
+    final Set<NetworkClient<Web3j>> networkClients = networkClientService.getAllMatching(network);
 
-    for (BlockchainNetworkConfiguration eligibleNetwork : eligibleNetworks) {
-      final String serverUrl = eligibleNetwork.getAddress();
+    for (NetworkClient<Web3j> networkClient : networkClients) {
+      final String serverUrl = networkClient.getNetwork().getAddress();
       try {
-        final Web3j client = serverClients.get(serverUrl);
+        final Web3j client = networkClient.getClient();
         final EthGasPrice gasPrice = client.ethGasPrice().sendAsync().get(30, TimeUnit.SECONDS);
         return new BlockchainFee()
             .server(toHost(serverUrl))
@@ -197,11 +178,8 @@ public class EthereumGateway implements
   @Override
   public BlockchainAccountInfo getAccount(String network, String accountId)
       throws UnknownNetworkException {
-    final List<BlockchainNetworkConfiguration> eligibleNetworks = this.configuration.getNetworks()
-        .stream()
-        .filter(n -> n.getGroup().equalsIgnoreCase(network))
-        .collect(Collectors.toList());
-    if (eligibleNetworks.size() == 0) {
+    final Set<NetworkClient<Web3j>> networkClients = networkClientService.getAllMatching(network);
+    if (networkClients.size() == 0) {
       // we could not find the specified network
       throw new UnknownNetworkException(CHAIN_ID, network);
     }
@@ -211,9 +189,9 @@ public class EthereumGateway implements
         .accountId(accountId)
         .network(network);
 
-    for (BlockchainNetworkConfiguration eligibleNetwork : eligibleNetworks) {
-      final String serverUrl = eligibleNetwork.getAddress();
-      final Web3j client = serverClients.get(serverUrl);
+    for (NetworkClient<Web3j> networkClient : networkClients) {
+      final String serverUrl = networkClient.getNetwork().getAddress();
+      final Web3j client = networkClient.getClient();
       try {
         final EthGetBalance balance = client
             .ethGetBalance(accountId, DefaultBlockParameter.valueOf("latest")).sendAsync()
@@ -234,7 +212,7 @@ public class EthereumGateway implements
             .subAccounts(tokenService.getAllSubAccountInfo(network, accountId,
                 latestBlock));
       } catch (InterruptedException | ExecutionException | TimeoutException e) {
-        logger.warn("Unable to get eth.accountInfo, network=" + eligibleNetwork, e);
+        logger.warn("Unable to get eth.accountInfo, network=" + network, e);
       }
     }
     // todo pending lastTransactionId
@@ -369,13 +347,11 @@ public class EthereumGateway implements
   @Override
   public BlockchainAccountTransaction getTransaction(String network, String hash)
       throws UnknownNetworkException {
-    final List<BlockchainNetworkConfiguration> eligibleNetworks = this.configuration.getNetworks()
-        .stream()
-        .filter(n -> n.getGroup().equalsIgnoreCase(network))
-        .collect(Collectors.toList());
-    for (BlockchainNetworkConfiguration eligibleNetwork : eligibleNetworks) {
-      final String serverUrl = eligibleNetwork.getAddress();
-      final Web3j client = serverClients.get(serverUrl);
+    final Set<NetworkClient<Web3j>> networkClients = networkClientService.getAllMatching(network);
+
+    for (NetworkClient<Web3j> networkClient : networkClients) {
+      final String serverUrl = networkClient.getNetwork().getAddress();
+      final Web3j client = networkClient.getClient();
       try {
         final EthTransaction ethTransaction = client.ethGetTransactionByHash(hash).sendAsync()
             .get(30, TimeUnit.SECONDS);
@@ -434,13 +410,10 @@ public class EthereumGateway implements
   @Override
   public SubmitTransactionResult submitTransaction(String network,
       SubmitTransactionRequest submitTransactionRequest) throws UnknownNetworkException {
-    final List<BlockchainNetworkConfiguration> eligibleNetworks = this.configuration.getNetworks()
-        .stream()
-        .filter(n -> n.getGroup().equalsIgnoreCase(network))
-        .collect(Collectors.toList());
-    for (BlockchainNetworkConfiguration eligibleNetwork : eligibleNetworks) {
-      final String serverUrl = eligibleNetwork.getAddress();
-      final Web3j client = serverClients.get(serverUrl);
+    final Set<NetworkClient<Web3j>> networkClients = networkClientService.getAllMatching(network);
+    for (NetworkClient<Web3j> networkClient : networkClients) {
+      final String serverUrl = networkClient.getNetwork().getAddress();
+      final Web3j client = networkClient.getClient();
       final EthSendTransaction response;
       try {
         response = client

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
@@ -91,6 +91,7 @@ public class EthereumGateway implements
         .distinct()
         .forEach(a -> {
           final Web3j client = Web3j.build(new HttpService(a));
+          logger.info("Connected to eth node {}", a);
           this.serverClients.put(a, client);
         });
 

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGateway.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.web3j.protocol.Web3j;
@@ -99,7 +100,7 @@ public class EthereumGateway implements
         .expireAfterWrite(10, TimeUnit.SECONDS)
         .build(new CacheLoader<>() {
           @Override
-          public EthBlock load(String network) throws Exception {
+          public EthBlock load(@NotNull String network) throws Exception {
             final Web3j client = serverClients.get(network);
             return client.ethGetBlockByNumber(DefaultBlockParameter.valueOf("latest"), false)
                 .sendAsync().get(30, TimeUnit.SECONDS);

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
@@ -51,7 +51,7 @@ public class EthereumGatewayConfiguration {
   }
 
   @Bean(BEAN_ETHEREUM_GATEWAY)
-  public EthereumGateway xrpGateway(YamlConfiguration configuration,
+  public EthereumGateway ethereumGateway(YamlConfiguration configuration,
       EtherscanUtil etherscanUtil,
       Erc20TokenService erc20TokenService) {
     return new EthereumGateway(configuration, etherscanUtil, erc20TokenService);

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
@@ -51,10 +51,9 @@ public class EthereumGatewayConfiguration {
   }
 
   @Bean(BEAN_ETHEREUM_GATEWAY)
-  public EthereumGateway ethereumGateway(YamlConfiguration configuration,
-      EtherscanUtil etherscanUtil,
+  public EthereumGateway ethereumGateway(EtherscanUtil etherscanUtil,
       Erc20TokenService erc20TokenService,
       @Qualifier(BEAN_ETH_NETWORK_SERVICE) NetworkClientService<Web3j> ethNetworkClientService) {
-    return new EthereumGateway(configuration, etherscanUtil, erc20TokenService, ethNetworkClientService);
+    return new EthereumGateway(etherscanUtil, erc20TokenService, ethNetworkClientService);
   }
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/EthereumGatewayConfiguration.java
@@ -53,7 +53,8 @@ public class EthereumGatewayConfiguration {
   @Bean(BEAN_ETHEREUM_GATEWAY)
   public EthereumGateway ethereumGateway(YamlConfiguration configuration,
       EtherscanUtil etherscanUtil,
-      Erc20TokenService erc20TokenService) {
-    return new EthereumGateway(configuration, etherscanUtil, erc20TokenService);
+      Erc20TokenService erc20TokenService,
+      @Qualifier(BEAN_ETH_NETWORK_SERVICE) NetworkClientService<Web3j> ethNetworkClientService) {
+    return new EthereumGateway(configuration, etherscanUtil, erc20TokenService, ethNetworkClientService);
   }
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestTemplate;
@@ -99,7 +100,7 @@ public class XrpGateway implements BlockchainGateway {
         .expireAfterWrite(SERVER_INFO_CACHE_EXPIRY)
         .build(new CacheLoader<>() {
           @Override
-          public ServerInfoResponse load(String key) throws Exception {
+          public ServerInfoResponse load(@NotNull String key) throws Exception {
             return serverClients.get(key).getServerInfo();
           }
         });
@@ -108,7 +109,7 @@ public class XrpGateway implements BlockchainGateway {
         .expireAfterWrite(Duration.of(30, ChronoUnit.SECONDS))
         .build(new CacheLoader<>() {
           @Override
-          public AccountInfoResponse load(String key) throws Exception {
+          public AccountInfoResponse load(@NotNull String key) throws Exception {
             final String[] tokens = key.split("\\|");
             final String serverUrl = tokens[0];
             final String address = tokens[1];
@@ -120,7 +121,7 @@ public class XrpGateway implements BlockchainGateway {
         .expireAfterWrite(Duration.of(1, ChronoUnit.MINUTES))
         .build(new CacheLoader<>() {
           @Override
-          public FeeResponse load(String key) throws Exception {
+          public FeeResponse load(@NotNull String key) throws Exception {
             return serverClients.get(key).getFee();
           }
         });

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
@@ -392,7 +392,7 @@ public class XrpGateway implements BlockchainGateway {
                   )
                   .type(tx.getTransactionType())
                   .hash(tx.getHash())
-                  .status(toSimpleStatus(meta != null ? meta.getTransactionResult() : "unknown"))
+                  .status(meta != null ? toSimpleStatus(meta.getTransactionResult()) : "unknown")
           );
     }
     return null;
@@ -441,6 +441,8 @@ public class XrpGateway implements BlockchainGateway {
 
   private String toSimpleStatus(String transactionResult) {
     // as per https://xrpl.org/transaction-results.html
+    if (transactionResult == null) return "null";
+
     if (transactionResult.startsWith("tes") && transactionResult.endsWith("SUCCESS")) {
       return "success";
     }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
@@ -145,6 +145,11 @@ public class XrpGateway implements BlockchainGateway {
     final Set<NetworkClient<PublicRippledClient>> clients = networkClientService
         .getAllMatching(network);
 
+    if (clients.size() == 0) {
+      // we could not find the specified network
+      throw new UnknownNetworkException(CHAIN_ID, network);
+    }
+
     return clients.stream()
         .map(networkClient -> {
           final BlockchainNetworkConfiguration networkConfiguration = networkClient.getNetwork();

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGateway.java
@@ -120,7 +120,7 @@ public class XrpGateway implements BlockchainGateway {
 
   @Override
   public String[] getNetworks() {
-    return configuration.getNetworks()
+    return networkClientService.getNetworks()
         .stream()
         .map(BlockchainNetworkConfiguration::getGroup)
         .distinct()

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
@@ -1,7 +1,10 @@
 package app.keyconnect.server.gateways;
 
+import app.keyconnect.rippled.api.client.PublicRippledClient;
 import app.keyconnect.rippled.api.spring.JacksonConfig;
 import app.keyconnect.server.factories.configuration.YamlConfiguration;
+import app.keyconnect.server.services.networks.NetworkClientService;
+import app.keyconnect.server.services.networks.XrpNetworkClientService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -11,7 +14,18 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 @Import({JacksonConfig.class, YamlConfiguration.class})
 public class XrpGatewayConfiguration {
 
-  @Bean("XrpGateway")
+  private static final String BEAN_XRP_NETWORK_SERVICE = "xrpNetworkService";
+  private static final String XRP_GATEWAY = "XrpGateway";
+
+  @Bean(BEAN_XRP_NETWORK_SERVICE)
+  public NetworkClientService<PublicRippledClient> xrpNetworkClientService(
+      YamlConfiguration yamlConfiguration,
+      MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter) {
+    return new XrpNetworkClientService(yamlConfiguration,
+        () -> JacksonConfig.constructRestTemplate(mappingJackson2HttpMessageConverter));
+  }
+
+  @Bean(XRP_GATEWAY)
   public XrpGateway xrpGateway(YamlConfiguration configuration,
       MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter) {
     return new XrpGateway(configuration,

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
@@ -27,9 +27,9 @@ public class XrpGatewayConfiguration {
   }
 
   @Bean(XRP_GATEWAY)
-  public XrpGateway xrpGateway(YamlConfiguration configuration,
+  public XrpGateway xrpGateway(
       @Qualifier(BEAN_XRP_NETWORK_SERVICE) NetworkClientService<PublicRippledClient> xrpNetworkClientService) {
-    return new XrpGateway(configuration, xrpNetworkClientService);
+    return new XrpGateway(xrpNetworkClientService);
   }
 
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/gateways/XrpGatewayConfiguration.java
@@ -5,6 +5,7 @@ import app.keyconnect.rippled.api.spring.JacksonConfig;
 import app.keyconnect.server.factories.configuration.YamlConfiguration;
 import app.keyconnect.server.services.networks.NetworkClientService;
 import app.keyconnect.server.services.networks.XrpNetworkClientService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -27,9 +28,8 @@ public class XrpGatewayConfiguration {
 
   @Bean(XRP_GATEWAY)
   public XrpGateway xrpGateway(YamlConfiguration configuration,
-      MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter) {
-    return new XrpGateway(configuration,
-        () -> JacksonConfig.constructRestTemplate(mappingJackson2HttpMessageConverter));
+      @Qualifier(BEAN_XRP_NETWORK_SERVICE) NetworkClientService<PublicRippledClient> xrpNetworkClientService) {
+    return new XrpGateway(configuration, xrpNetworkClientService);
   }
 
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/Erc20TokenService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/Erc20TokenService.java
@@ -6,6 +6,7 @@ import static app.keyconnect.server.gateways.EthereumGateway.SCALE;
 
 import app.keyconnect.api.client.model.GenericCurrencyValue;
 import app.keyconnect.api.client.model.SubAccountInfo;
+import app.keyconnect.server.services.networks.NetworkClient;
 import app.keyconnect.server.services.networks.NetworkClientService;
 import app.keyconnect.server.utils.EtherscanUtil;
 import app.keyconnect.server.utils.models.EtherscanAccountTransaction;
@@ -141,8 +142,9 @@ public class Erc20TokenService {
   }
 
   private SubAccountInfo getSubAccountInfo(String network, String address, Erc20Token token) {
-    final Web3j client = ethNetworkClientService.getClients(network).stream().findFirst()
+    final NetworkClient<Web3j> networkClient = ethNetworkClientService.getAllMatching(network).stream().findFirst()
         .orElseThrow();
+    final Web3j client = networkClient.getClient();
     // get credentials from credentials service
     final Credentials credentials = ethCredentialsService.getCredentials();
     // load contract hash

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/EthNetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/EthNetworkClientService.java
@@ -10,11 +10,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.http.HttpService;
 
+/**
+ * {@link NetworkClientService} implementation for Ethereum based on {@link Web3j} client
+ */
 public class EthNetworkClientService implements NetworkClientService<Web3j> {
 
+  private static final Logger logger = LoggerFactory.getLogger(EthNetworkClientService.class);
   private final BlockchainsConfiguration configuration;
   private final Map<String, Web3j> serverClients;
 
@@ -32,22 +38,44 @@ public class EthNetworkClientService implements NetworkClientService<Web3j> {
         .distinct()
         .forEach(a -> {
           final Web3j client = Web3j.build(new HttpService(a));
+          logger.info("Connected to node {}", a);
           this.serverClients.put(a, client);
         });
   }
 
-  public Set<Web3j> getClients(String network) {
+  public Set<NetworkClient<Web3j>> getAllMatching(String network) {
     final List<BlockchainNetworkConfiguration> networks = this.configuration.getNetworks()
         .stream()
         .filter(n -> n.getGroup().equalsIgnoreCase(network))
         .collect(Collectors.toList());
 
-    final Set<Web3j> clientSet = new HashSet<>(networks.size());
+    final Set<NetworkClient<Web3j>> clientSet = new HashSet<>(networks.size());
     for (BlockchainNetworkConfiguration eligibleNetwork : networks) {
       final String serverUrl = eligibleNetwork.getAddress();
-      clientSet.add(this.serverClients.get(serverUrl));
+      // todo maybe cache the whole thing in `this.serverClients`?
+      clientSet.add(new NetworkClient<>(this.serverClients.get(serverUrl), eligibleNetwork));
     }
 
     return clientSet;
+  }
+
+  /**
+   * Returns the first client found for a given network
+   * @param network Network to return the blockchain client for.
+   * @return First Web3j client found for the specified network.
+   */
+  @Override
+  public NetworkClient<Web3j> getFirst(String network) {
+    return this.configuration.getNetworks()
+        .stream()
+        .filter(n -> n.getGroup().equalsIgnoreCase(network))
+        .findFirst()
+        .map(n -> new NetworkClient<>(this.serverClients.get(n.getAddress()), n))
+        .orElse(null);
+  }
+
+  @Override
+  public Web3j getClientForServer(String serverUrl) {
+    return this.serverClients.get(serverUrl);
   }
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/EthNetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/EthNetworkClientService.java
@@ -43,6 +43,7 @@ public class EthNetworkClientService implements NetworkClientService<Web3j> {
         });
   }
 
+
   public Set<NetworkClient<Web3j>> getAllMatching(String network) {
     final List<BlockchainNetworkConfiguration> networks = this.configuration.getNetworks()
         .stream()
@@ -77,5 +78,10 @@ public class EthNetworkClientService implements NetworkClientService<Web3j> {
   @Override
   public Web3j getClientForServer(String serverUrl) {
     return this.serverClients.get(serverUrl);
+  }
+
+  @Override
+  public List<BlockchainNetworkConfiguration> getNetworks() {
+    return this.configuration.getNetworks();
   }
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClient.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClient.java
@@ -1,0 +1,14 @@
+package app.keyconnect.server.services.networks;
+
+import app.keyconnect.server.factories.configuration.BlockchainNetworkConfiguration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NetworkClient<T> {
+
+  private final T client;
+  private final BlockchainNetworkConfiguration network;
+
+}

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClientService.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public interface NetworkClientService<T> {
 
-  Set<T> getClients(String network);
+  Set<NetworkClient<T>> getAllMatching(String network);
+  NetworkClient<T> getFirst(String network);
+  T getClientForServer(String serverUrl);
 
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/NetworkClientService.java
@@ -1,5 +1,7 @@
 package app.keyconnect.server.services.networks;
 
+import app.keyconnect.server.factories.configuration.BlockchainNetworkConfiguration;
+import java.util.List;
 import java.util.Set;
 
 public interface NetworkClientService<T> {
@@ -7,5 +9,6 @@ public interface NetworkClientService<T> {
   Set<NetworkClient<T>> getAllMatching(String network);
   NetworkClient<T> getFirst(String network);
   T getClientForServer(String serverUrl);
+  List<BlockchainNetworkConfiguration> getNetworks();
 
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/XrpNetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/XrpNetworkClientService.java
@@ -72,4 +72,9 @@ public class XrpNetworkClientService implements NetworkClientService<PublicRippl
   public PublicRippledClient getClientForServer(String serverUrl) {
     return this.serverClients.get(serverUrl);
   }
+
+  @Override
+  public List<BlockchainNetworkConfiguration> getNetworks() {
+    return this.configuration.getNetworks();
+  }
 }

--- a/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/XrpNetworkClientService.java
+++ b/keyconnect-server/src/main/java/app/keyconnect/server/services/networks/XrpNetworkClientService.java
@@ -1,0 +1,75 @@
+package app.keyconnect.server.services.networks;
+
+import app.keyconnect.rippled.api.client.PublicRippledClient;
+import app.keyconnect.rippled.api.client.config.PublicRippledClientConfig;
+import app.keyconnect.server.factories.configuration.BlockchainNetworkConfiguration;
+import app.keyconnect.server.factories.configuration.BlockchainsConfiguration;
+import app.keyconnect.server.factories.configuration.YamlConfiguration;
+import app.keyconnect.server.gateways.XrpGateway;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.springframework.web.client.RestTemplate;
+
+public class XrpNetworkClientService implements NetworkClientService<PublicRippledClient> {
+
+  private final BlockchainsConfiguration configuration;
+  // key is serverUrl
+  private final Map<String, PublicRippledClient> serverClients;
+
+  public XrpNetworkClientService(YamlConfiguration yamlConfiguration,
+      Supplier<RestTemplate> restTemplateSupplier) {
+    this.configuration = yamlConfiguration.getBlockchains()
+        .stream()
+        .filter(b -> b.getType().equalsIgnoreCase(XrpGateway.CHAIN_ID))
+        .findFirst()
+        .orElse(new BlockchainsConfiguration());
+
+    this.serverClients = new ConcurrentHashMap<>(this.configuration.getNetworks().size());
+
+    this.configuration.getNetworks()
+        .stream()
+        .map(BlockchainNetworkConfiguration::getAddress)
+        .distinct()
+        .forEach(a -> {
+          final PublicRippledClient client = new PublicRippledClient(restTemplateSupplier.get(),
+              PublicRippledClientConfig.builder().jsonRpcEndpoint(a).build());
+          this.serverClients.put(a, client);
+        });
+  }
+
+  @Override
+  public Set<NetworkClient<PublicRippledClient>> getAllMatching(String network) {
+    final List<BlockchainNetworkConfiguration> networks = configuration.getNetworks()
+        .stream()
+        .filter(n -> n.getGroup().equalsIgnoreCase(network))
+        .collect(Collectors.toList());
+    final Set<NetworkClient<PublicRippledClient>> clientSet = new HashSet<>(networks.size());
+    for (BlockchainNetworkConfiguration eligibleNetwork : networks) {
+      final String serverUrl = eligibleNetwork.getAddress();
+      // todo maybe cache the whole thing in `this.serverClients`?
+      clientSet.add(new NetworkClient<>(this.serverClients.get(serverUrl), eligibleNetwork));
+    }
+
+    return clientSet;
+  }
+
+  @Override
+  public NetworkClient<PublicRippledClient> getFirst(String network) {
+    return this.configuration.getNetworks()
+        .stream()
+        .filter(n -> n.getGroup().equalsIgnoreCase(network))
+        .findFirst()
+        .map(n -> new NetworkClient<>(this.serverClients.get(n.getAddress()), n))
+        .orElse(null);
+  }
+
+  @Override
+  public PublicRippledClient getClientForServer(String serverUrl) {
+    return this.serverClients.get(serverUrl);
+  }
+}

--- a/keyconnect-server/src/test/java/app/keyconnect/server/gateways/EthereumGatewayTest.java
+++ b/keyconnect-server/src/test/java/app/keyconnect/server/gateways/EthereumGatewayTest.java
@@ -49,7 +49,7 @@ public class EthereumGatewayTest {
       networkClientService = new EthNetworkClientService(yamlConfiguration);
     }
 
-    subject = new EthereumGateway(yamlConfiguration, mockEtherscan, mockTokenService,
+    subject = new EthereumGateway(mockEtherscan, mockTokenService,
         networkClientService);
   }
 

--- a/keyconnect-server/src/test/java/app/keyconnect/server/gateways/EthereumGatewayTest.java
+++ b/keyconnect-server/src/test/java/app/keyconnect/server/gateways/EthereumGatewayTest.java
@@ -15,6 +15,8 @@ import app.keyconnect.api.client.model.CurrencyValue;
 import app.keyconnect.api.client.model.CurrencyValue.CurrencyEnum;
 import app.keyconnect.server.factories.configuration.YamlConfiguration;
 import app.keyconnect.server.services.Erc20TokenService;
+import app.keyconnect.server.services.networks.EthNetworkClientService;
+import app.keyconnect.server.services.networks.NetworkClientService;
 import app.keyconnect.server.utils.EtherscanUtil;
 import app.keyconnect.server.utils.models.EtherscanAccountTransaction;
 import app.keyconnect.server.utils.models.EtherscanResponse;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.web3j.protocol.Web3j;
 
 @SpringBootTest
 public class EthereumGatewayTest {
@@ -35,12 +38,19 @@ public class EthereumGatewayTest {
   private BlockchainGateway subject;
   private EtherscanUtil mockEtherscan;
   private Erc20TokenService mockTokenService;
+  private NetworkClientService<Web3j> networkClientService;
 
   @BeforeEach
   public void setUp() throws Exception {
     mockEtherscan = mock(EtherscanUtil.class);
     mockTokenService = mock(Erc20TokenService.class);
-    subject = new EthereumGateway(yamlConfiguration, mockEtherscan, mockTokenService);
+
+    if (networkClientService == null) {
+      networkClientService = new EthNetworkClientService(yamlConfiguration);
+    }
+
+    subject = new EthereumGateway(yamlConfiguration, mockEtherscan, mockTokenService,
+        networkClientService);
   }
 
   @Test

--- a/keyconnect-server/src/test/java/app/keyconnect/server/gateways/XrpGatewayTest.java
+++ b/keyconnect-server/src/test/java/app/keyconnect/server/gateways/XrpGatewayTest.java
@@ -1,9 +1,12 @@
 package app.keyconnect.server.gateways;
 
-import app.keyconnect.rippled.api.spring.JacksonConfig;
 import app.keyconnect.api.client.model.BlockchainAccountTransactions;
+import app.keyconnect.rippled.api.client.PublicRippledClient;
+import app.keyconnect.rippled.api.spring.JacksonConfig;
 import app.keyconnect.server.factories.configuration.YamlConfiguration;
 import app.keyconnect.server.gateways.exceptions.UnknownNetworkException;
+import app.keyconnect.server.services.networks.NetworkClientService;
+import app.keyconnect.server.services.networks.XrpNetworkClientService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,12 +20,16 @@ public class XrpGatewayTest {
 
   @Test
   void testGetTransactions() {
-    final XrpGateway gateway = new XrpGateway(
+    final NetworkClientService<PublicRippledClient> networkClientService = new XrpNetworkClientService(
         yamlConfiguration,
         () -> {
           final JacksonConfig jacksonConfig = new JacksonConfig();
           return (RestTemplate) jacksonConfig.restOperations(jacksonConfig.mappingJacksonHttpMessageConverter(jacksonConfig.objectMapper()));
         }
+    );
+    final XrpGateway gateway = new XrpGateway(
+        yamlConfiguration,
+        networkClientService
     );
     try {
       final BlockchainAccountTransactions transactions = gateway

--- a/keyconnect-server/src/test/java/app/keyconnect/server/gateways/XrpGatewayTest.java
+++ b/keyconnect-server/src/test/java/app/keyconnect/server/gateways/XrpGatewayTest.java
@@ -28,7 +28,6 @@ public class XrpGatewayTest {
         }
     );
     final XrpGateway gateway = new XrpGateway(
-        yamlConfiguration,
         networkClientService
     );
     try {


### PR DESCRIPTION
Gateways have logic baked in to create relevant network clients. This is polluting the gateway code at the moment since there is a lot of logic involved in not only creating the network clients but also evaluating it against available networks on calls.

- [x] Ethereum Gateway implementation
- [x] XrpNetworkClientService
- [x] Xrp Gateway implementation